### PR TITLE
Fix deadlock in watch_only

### DIFF
--- a/lib/AnyEvent/Beanstalk.pm
+++ b/lib/AnyEvent/Beanstalk.pm
@@ -313,6 +313,7 @@ sub watch_only {
       foreach my $t (@$tubes) {
         $tubes{$t} = 0 unless delete $tubes{$t};
       }
+      $done->() if !keys %tubes;
       foreach my $t (sort { $tubes{$b} <=> $tubes{$a} } keys %tubes) {
         my $cmd = $tubes{$t} ? 'watch' : 'ignore';
         $self->run_cmd(


### PR DESCRIPTION
Previously, if the set of tubes to watch was the same as the set of tubes
currently watched, watch_only would deadlock because $done->() was never
called.

Calling $done->() when there is no work to do solves this.
