### PR TITLE
call stats_job to get info for particular job

### DIFF
--- a/lib/AnyEvent/Beanstalk/Job.pm
+++ b/lib/AnyEvent/Beanstalk/Job.pm
@@ -14,7 +14,7 @@ sub new {
 
 sub stats {
   my $self = shift;
-  my ($stats, $err) = $self->client->stats($self->id)->recv;
+  my ($stats, $err) = $self->client->stats_job($self->id)->recv;
   return $self->{_stats} = $stats if $stats;
   $self->error($err || 'unknown');
   return undef;


### PR DESCRIPTION
I think this was just an oversight..stats_job should be called to get job specific data
