### PR TITLE
Fixes to watch_only()

### DIFF
--- a/lib/AnyEvent/Beanstalk.pm
+++ b/lib/AnyEvent/Beanstalk.pm
@@ -412,7 +412,7 @@ sub use {
   $self->run_cmd(
     'use' => $tube,
     sub {
-      $self->{__using} = $_[0] if @_ and $_[1] =~ /^USING/;
+      $self->{__using} = $_[0] if @_ and $_[1] =~ /^USING\b/;
       $cb[0]->(@_) if @cb;
     }
   );
@@ -478,7 +478,7 @@ sub watch {
   $self->run_cmd(
     'watch' => $tube,
     sub {
-      $self->{__watching}{$tube} = 1 if @_ and $_[1] =~ /^WATCHING/;
+      $self->{__watching}{$tube} = 1 if @_ and $_[1] =~ /^WATCHING\b/;
       $cb[0]->(@_) if @cb;
     }
   );
@@ -493,7 +493,7 @@ sub ignore {
   $self->run_cmd(
     'ignore' => $tube,
     sub {
-      delete $self->{__watching}{$tube} if @_ and $_[1] =~ /^WATCHING/;
+      delete $self->{__watching}{$tube} if @_ and $_[1] =~ /^WATCHING\b/;
       $cb[0]->(@_) if @cb;
     }
   );

--- a/lib/AnyEvent/Beanstalk.pm
+++ b/lib/AnyEvent/Beanstalk.pm
@@ -1354,7 +1354,7 @@ Same as C<disconnect>
 
 More tests
 
-=head1 ACKNOWLEDGEMTS
+=head1 ACKNOWLEDGEMENTS
 
 Large parts of this documention were lifted from the documention that comes with
 beanstalkd

--- a/lib/AnyEvent/Beanstalk.pm
+++ b/lib/AnyEvent/Beanstalk.pm
@@ -873,7 +873,7 @@ Stop watching C<$tube>
 
 The response value for C<ignore> is the number of tubes being watched
 
-=item B<watch_only (@tubes)>
+=item B<watch_only (@tubes, [$callback])>
 
 C<watch_only> will submit a C<list_tubes_watching> command then submit C<watch> and C<ignore>
 command to make the list match.

--- a/lib/AnyEvent/Beanstalk.pm
+++ b/lib/AnyEvent/Beanstalk.pm
@@ -315,7 +315,10 @@ sub watch_only {
         $tubes{$t} = 0 unless delete $tubes{$t};
         $w->{$t}++;
       }
-      $done->() if !keys %tubes;
+      unless (keys %tubes) {    # nothing to do
+          my $ts = scalar @$tubes;
+          $done->($ts, "WATCHING $ts");
+      }
       my @err;    # first error
       foreach my $t (sort { $tubes{$b} <=> $tubes{$a} } keys %tubes) {
         my $cmd = $tubes{$t} ? 'watch' : 'ignore';

--- a/lib/AnyEvent/Beanstalk.pm
+++ b/lib/AnyEvent/Beanstalk.pm
@@ -320,12 +320,11 @@ sub watch_only {
         $self->run_cmd(
           $cmd, $t,
           sub {
-            my ($r) = @_;
             return unless keys %tubes;
             delete $tubes{$t};
             return $done->(@_)
               if !@_
-                or $r ne 'WATCHING'
+                or $_[1] and $_[1] !~ /^WATCHING\b/
                 or !keys %tubes;
           }
         );

--- a/lib/AnyEvent/Beanstalk.pm
+++ b/lib/AnyEvent/Beanstalk.pm
@@ -297,7 +297,7 @@ sub watch_only {
 
   unless (@_) {
     delete $self->{_condvar}{$cv};
-    $cv->send('NOT_IGNORED');
+    $cv->send(undef, 'NOT_IGNORED');
     return $cv;
   }
 

--- a/lib/AnyEvent/Beanstalk/Job.pm
+++ b/lib/AnyEvent/Beanstalk/Job.pm
@@ -134,7 +134,7 @@ on the condition variable returned by L<AnyEvent::Beanstalk>. If this is undesir
 then a call can be made directly to the server via methods on the client.
 
 Note however that beanstalkd processes command in sequence. So if there is currently
-a reserve request pending. Any calls to these methods will not return until the
+a reserve request pending, any calls to these methods will not return until the
 reserve command has returned so that beanstalkd can process any subsequent commands.
 
 =head1 METHODS

--- a/t/03-watch-only.t
+++ b/t/03-watch-only.t
@@ -1,0 +1,35 @@
+#!/usr/bin/env perl
+
+use AnyEvent::Beanstalk;
+use Test::More;
+use Test::Deep;
+use Test::Warnings;
+use t::start_server;
+
+my $c = get_client();
+
+plan tests => 7 + 1;
+
+my $ts = $c->list_tubes_watched()->recv;
+cmp_deeply($ts, bag('default'));
+
+cmp_deeply([$c->watching], bag('default'));
+
+$c->watch_only('default')->recv;
+cmp_deeply([$c->watching], bag('default'));
+
+$c->watch_only('t1')->recv;
+cmp_deeply([$c->watching], bag('t1'));
+
+$c->watch_only('t1', 't2')->recv;
+cmp_deeply([$c->watching], bag('t1', 't2'));
+
+$c->watch_only('t1', 't2')->recv;
+cmp_deeply([$c->watching], bag('t1', 't2'));
+
+my @r = $c->watch_only('t3', 't4')->recv;
+cmp_deeply([$c->watching], bag('t3', 't4'));
+
+done_testing;
+
+


### PR DESCRIPTION
* fix check on Beanstalk responses
* don't bail on first error
* reply `($n_tubes, "WATCHING $n_tubes")` on same tubes
* reply `(undef, 'NOT_IGNORED')` on no tubes
* track watched tubes
